### PR TITLE
fix: issues: Fails for import statement with no name #2

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,10 +36,18 @@ module.exports = function(/*babel*/) {
           // const jssObject = cssToJss({ code });
           // writeJssFile(jssObject, src);
 
-          babelData.replaceWithMultiple([
-            classesMapConstAst({ classesMap, importNode }),
-            putStyleIntoHeadAst({ code }),
-          ]);
+          // issues: Fails for import statement with no name #2
+          if (importNode.local) {
+            babelData.replaceWithMultiple([
+              classesMapConstAst({ classesMap, importNode }),
+              putStyleIntoHeadAst({ code }),
+            ]);
+          } else {
+            babelData.replaceWithMultiple([
+              putStyleIntoHeadAst({ code }),
+            ]);
+          }
+          
         }),
       },
     },


### PR DESCRIPTION
Support import statement with no name.
```javascript
import './index.css';
```
will be transformed like:
```javascript
require('load-styles')('.root{color:red}; ...some css...') // puts styles into the head
```