### PR TITLE
Fix: Empty config crash caused by repeated require()

### DIFF
--- a/postcss.js
+++ b/postcss.js
@@ -72,6 +72,7 @@ function loadConfig(configPath) {
 function loadRawConf(configPath) {
   const jsConfPath = /\.js$/.test(configPath) ? configPath : path.resolve(PWD, 'postcss.config.js');
   if (fs.existsSync(jsConfPath)) {
+    delete require.cache[require.resolve(jsConfPath)];
     const conf = require(jsConfPath);
     return { conf, confPath: jsConfPath };
   }


### PR DESCRIPTION
For whatever reason, babel is currently calling this plugin twice in my project (I verified this with console logs). Due to the way Node handles repeated requires, the require() call on my `postcss.config.js` was returning an empty object on the subsequent call. This in turn causes an error from `postcss-load-config`, which doesn't handle an empty config object correctly (and it would end up with the wrong options even if it did).

The one-line addition in this PR just clears any existing config from Node's resolve cache so that the file will be reimported every time. This fixes the issue.